### PR TITLE
Fix deprecated use of `spack.repo.get` in favour of newer `spack.repo.path.get_pkg_class`

### DIFF
--- a/spack-allinone.py
+++ b/spack-allinone.py
@@ -239,7 +239,7 @@ def detect_executables():
     # Cray compiler wrapper, or even module unload xyz, it fails, since Spack's
     # pkg-config has different default paths. So, the easiest solution is to
     # define pkg-config as an external and hope Spack uses this one by default.
-    return spack.detection.by_executable([spack.repo.get('pkg-config')])['pkg-config']
+    return spack.detection.by_executable([spack.repo.path.get_pkg_class('pkg-config')])['pkg-config']
 
 
 def to_config_data(packages):


### PR DESCRIPTION
FIY @toxa81 this PR fixes the error

```
Traceback (most recent call last):
  File "spack-allinone.py", line 299, in <module>
    pkgs.extend(detect_executables())
  File "spack-allinone.py", line 242, in detect_executables
    return spack.detection.by_executable([spack.repo.get('pkg-config')])['pkg-config']
AttributeError: module 'spack.repo' has no attribute 'get'
```

that arose with newer version of spack because of the deprecation and removal of that function in https://github.com/spack/spack/pull/31411.

The function `spack.detection.by_executable` requires a (list of) package(s) (and not a concretised spec), for this reason I opted for `spack.repo.path.get_pkg_class`.

