### PR TITLE
Fix after `spack.detection.by_executable` has been removed

### DIFF
--- a/spack-allinone.py
+++ b/spack-allinone.py
@@ -292,7 +292,7 @@ def detect_executables():
     # Cray compiler wrapper, or even module unload xyz, it fails, since Spack's
     # pkg-config has different default paths. So, the easiest solution is to
     # define pkg-config as an external and hope Spack uses this one by default.
-    return spack.detection.by_executable([spack.repo.PATH.get_pkg_class('pkg-config')])['pkg-config']
+    return spack.detection.by_path(['pkg-config'])['pkg-config']
 
 
 def to_config_data(packages):


### PR DESCRIPTION
Changed according to https://github.com/spack/spack/pull/39843

```console
[hohgant][ialberto@nid003192 spack-config-generator]$ spack python
Spack version 0.21.0.dev0
Python 3.6.15, Linux x86_64
>>> from spack.detection import by_path
>>> by_path(['pkg-config'])
defaultdict(<class 'list'>, {'pkg-config': [DetectedPackage(spec=pkg-config@0.29.2, prefix='/usr')]})
>>> by_path(['pkg-config'])['pkg-config']
[DetectedPackage(spec=pkg-config@0.29.2, prefix='/usr')]
```